### PR TITLE
fix spelling and remove auto increment from the queries

### DIFF
--- a/mysqlQuery/readme.md
+++ b/mysqlQuery/readme.md
@@ -22,7 +22,7 @@ CREATE TABLE `tbl_users` (
   `sec_key` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_type` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 ```
 
 - Query to manually insert and admin 
@@ -47,7 +47,7 @@ CREATE TABLE `tbl_sales` (
  `sale_type` tinyint(4) NOT NULL,
  `created_on` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 ```
 
 - Query to create tbl_servers table manually
@@ -65,7 +65,7 @@ CREATE TABLE `tbl_servers` (
  `vip_flag` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `created_at` datetime DEFAULT NULL,
  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 ```
 
 - Query to create tbl_settings table manually
@@ -75,7 +75,7 @@ CREATE TABLE `tbl_settings` (
  `setting_key` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
  `setting_value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 ```
 
 - Query to update table accroding to changes of v1.6

--- a/panelServer/app/db/db_bridge.js
+++ b/panelServer/app/db/db_bridge.js
@@ -53,7 +53,7 @@ const query = function (queryText, singleRecord) {
 };
 
 /**
- * shim for formating the query
+ * shim for formatting the query
  */
 var queryFormat = mysql.format;
 

--- a/panelServer/app/models/panelSettingModal.js
+++ b/panelServer/app/models/panelSettingModal.js
@@ -53,7 +53,7 @@ var settingsModal = {
                                     setting_key varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL,
                                     setting_value varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
                                     PRIMARY KEY(id)
-                                  ) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci`);
+                                  ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci`);
         let queryRes = await db.query(query, true);
         if (!queryRes) {
           return reject("Error in creating user table");

--- a/panelServer/app/models/userModel.js
+++ b/panelServer/app/models/userModel.js
@@ -45,7 +45,7 @@ var userDataModel = {
                                     sec_key varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL,
                                     user_type int(11) NOT NULL,
                                     PRIMARY KEY(id)
-                                  ) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci`);
+                                  ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci`);
         let queryRes = await db.query(query, true);
         if (!queryRes) {
           return reject("Error in creating user table");


### PR DESCRIPTION
- fix spelling
- remove auto increment from the queries which can cause to start from wrong id in some cases.